### PR TITLE
fixed bug caused by attempting to modify a list currently being iterated over

### DIFF
--- a/random task assignment program.ipynb
+++ b/random task assignment program.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -31,24 +31,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div>\n",
-       "<style>\n",
-       "    .dataframe thead tr:only-child th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: left;\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
        "    }\n",
        "\n",
        "    .dataframe tbody tr th {\n",
        "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
        "    }\n",
        "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -222,7 +222,7 @@
        "18        S                NaN                NaN                   NaN"
       ]
      },
-     "execution_count": 197,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -286,7 +286,7 @@
        "['B', 'D', 'E', 'G', 'I', 'K', 'L', 'M', 'N', 'O', 'P', 'S']"
       ]
      },
-     "execution_count": 199,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -299,16 +299,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['G', 'D']"
+       "['K', 'P']"
       ]
      },
-     "execution_count": 201,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -321,53 +321,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['L', 'K']"
+       "['G', 'O']"
       ]
      },
-     "execution_count": 202,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#Remove L&L leaders from population list and select Culture leaders\n",
+    "#Create culture list, remove L&L leaders from culture list and select Culture leaders\n",
+    "culture_list = population_list.copy()\n",
     "for i in population_list:\n",
     "    if i in LnL:\n",
-    "        population_list.remove(i)\n",
+    "        culture_list.remove(i)\n",
     "\n",
-    "Culture = random.sample(population_list, 2)\n",
+    "Culture = random.sample(culture_list, 2)\n",
     "Culture"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['I', 'E']"
+       "['S', 'M']"
       ]
      },
-     "execution_count": 203,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#Remove Culture leaders from population list and select Office Administration leaders\n",
-    "for i in population_list:\n",
+    "#Create office admin list, remove Culture leaders from office admin list, and select Office Administration leaders\n",
+    "office_admin_list = culture_list.copy()\n",
+    "for i in culture_list:\n",
     "    if i in Culture:\n",
-    "        population_list.remove(i)\n",
+    "        office_admin_list.remove(i)\n",
     "        \n",
-    "Office_Admin = random.sample(population_list, 2)\n",
+    "Office_Admin = random.sample(office_admin_list, 2)\n",
     "Office_Admin"
    ]
   }


### PR DESCRIPTION
It looks like the bug we experienced last time was caused by attempting to modify the same list we were iterating through with the for loop. See here for a stack exchange thread on it: https://stackoverflow.com/questions/10665591/how-to-remove-list-elements-in-a-for-loop-in-python

A future improvement could be to use a filter function instead of the for loop, but for now I just created new culture and office_admin lists so that we can iterate through the original list and modify copies.